### PR TITLE
WebSocket書き込みエラーの修正

### DIFF
--- a/backend/src/controller/poker_ingame_ws.go
+++ b/backend/src/controller/poker_ingame_ws.go
@@ -59,8 +59,8 @@ func WebSocketServer(w http.ResponseWriter, r *http.Request, rid string, uid str
 			} else {
 				log.Println("!!!")
 				log.Println(err)
-				(*user).WsConn = nil
-				(*user).SessionAlive = false
+				// (*user).WsConn = nil
+				// (*user).SessionAlive = false
 			}
 			conn.Close()
 			WritePokerRoombyWS(pr)
@@ -79,7 +79,7 @@ func WritePokerRoombyWS(pr *model.PokerRoom) {
 			if u.WsConn == nil {
 				// WsConnがnilでWriteJSONするとぬるぽ吐くので振り分け
 			} else if err := view.WriteRoomInfobyWS(u.WsConn, pr); err != nil {
-				u.WsConn.Close()
+				// u.WsConn.Close()
 				u.WsConn = nil
 				u.SessionAlive = false
 			}

--- a/backend/src/controller/poker_ingame_ws.go
+++ b/backend/src/controller/poker_ingame_ws.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"log"
 	"net/http"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
@@ -70,8 +71,11 @@ func WebSocketServer(w http.ResponseWriter, r *http.Request, rid string, uid str
 
 // PokerRoomの全てのUserにPokerRoomをJSONで送信
 func WritePokerRoombyWS(pr *model.PokerRoom) {
+	mu := sync.Mutex{}
 	for _, u := range pr.Users {
 		go func(u *model.User) {
+			mu.Lock()
+			defer mu.Unlock()
 			if u.WsConn == nil {
 				// WsConnがnilでWriteJSONするとぬるぽ吐くので振り分け
 			} else if err := view.WriteRoomInfobyWS(u.WsConn, pr); err != nil {


### PR DESCRIPTION
CloseされているWS ConnをCloseしようとした際に起きたエラー
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7628ce]
```
スレッドセーフな設計をしていなかったため、`if u.WsConn == nil {}`とか入れててもあまり効果がなかった 
対処法としては、sync.Mutex{}を使用するというのが考えられる

